### PR TITLE
FIX : Create project cancellation error

### DIFF
--- a/Configs/createdProjects.json
+++ b/Configs/createdProjects.json
@@ -1,1 +1,1 @@
-[]
+[{"path": "H:\\test", "name": "test", "timestamp": "1522527926.9"}]

--- a/execute.py
+++ b/execute.py
@@ -372,6 +372,10 @@ class MainWindow(QtGui.QMainWindow, Ui_MainWindow.Ui_MainWindow):
     def createAndOpenProject( self ):
         projectPath = QtGui.QFileDialog.getExistingDirectory( self, "Choose Project Directory" )
 
+        if projectPath.strip() == "" or projectPath == None:
+            self.log( Loggers.msgNormal( "The project creation was cancelled." ) )
+            return
+
         if ProjectManagers.isUsedProjectPath( projectPath=projectPath ):
             # Show a popup asking if the user wants to overwrite an old project
             confirmOverwrite = QtGui.QMessageBox.question( self, "Confirm Overwrite",


### PR DESCRIPTION
The log showed an error message when the create project process was cancelled at the first step.

Solution : The program checks if the filename is empty or null and displays a cancellation message accordingly.